### PR TITLE
Add Move Message Watcher

### DIFF
--- a/src/ACTION_IDENTIFIERS.md
+++ b/src/ACTION_IDENTIFIERS.md
@@ -8,6 +8,7 @@ This file will contain a list of action identifiers in the application
 - BLK002: Action buttons on the welcome message block.
 - BLK003: Remove watcher section block.
 - BLK004: Action buttons for removing watcher.
+- BLK005: Move to channel channel request message.
 
 ## Action IDs
 
@@ -16,6 +17,7 @@ This file will contain a list of action identifiers in the application
 - ACT003: Remove a channel watcher action trigger
 - ACT004: Remove channel watcher channel watcher option select
 - ACT005: Go back from the remove watcher selection message
+- ACT006: Add move message channel watcher
 
 ## Callback IDs
 

--- a/src/database/migrations/20190719125555_add_move_channel.sql
+++ b/src/database/migrations/20190719125555_add_move_channel.sql
@@ -1,0 +1,26 @@
+ALTER TABLE watching_channels ADD COLUMN move_channel_id VARCHAR (10);
+
+CREATE PROCEDURE add_new_move_watcher(channel_id_param VARCHAR (10), move_channel_id_param VARCHAR (10), team_id_param VARCHAR (80), emoji_text_param VARCHAR (50), reaction_limit_param INTEGER, tiddy_action_param VARCHAR (10))
+LANGUAGE plpgsql
+AS $$
+-- Declare variable
+DECLARE
+workspace_serial_id INTEGER;
+BEGIN
+  -- Get the workspace serial number
+  SELECT
+    id
+  INTO
+    workspace_serial_id
+  FROM
+    workspace
+  WHERE
+    team_id = team_id_param;
+
+  -- Add the new watching channel
+  INSERT INTO
+    watching_channels (workspace_id, channel_id, move_channel_id, emoji_text, reaction_limit, tiddy_action, created_at, updated_at)
+  VALUES
+    (workspace_serial_id, channel_id_param, move_channel_id_param, emoji_text_param, reaction_limit_param, tiddy_action_param, clock_timestamp(), clock_timestamp());
+END;
+$$;

--- a/src/routes/slack/SlackInteractiveMessage.ts
+++ b/src/routes/slack/SlackInteractiveMessage.ts
@@ -27,4 +27,7 @@ slackInteractions.action({ actionId: 'ACT004' }, ActionControllers.removeWatcher
 // Handle back button from add watcher selection message
 slackInteractions.action({ actionId: 'ACT005' }, ActionControllers.displayWelcomeMessage);
 
+// Handle add move message action
+slackInteractions.action({ actionId: /^ACT006.*/ }, ActionControllers.addMoveWatcher);
+
 export default slackInteractions;

--- a/src/services/WatcherServices.ts
+++ b/src/services/WatcherServices.ts
@@ -18,13 +18,23 @@ export default class WatcherServices {
     limit: number,
     action: string,
     teamId: string,
+    moveChannelId?: string,
   ): Promise<void> {
-    const query = 'CALL add_new_watching_channel($1, $2, $3, $4, $5)';
+    if (!moveChannelId) {
+      const query = 'CALL add_new_watching_channel($1, $2, $3, $4, $5)';
 
-    await client.query({
-      text: query,
-      values: [channelId, teamId, emojiText, limit, action],
-    });
+      await client.query({
+        text: query,
+        values: [channelId, teamId, emojiText, limit, action],
+      });
+    } else {
+      const query = 'CALL add_new_move_watcher($1, $2, $3, $4, $5, $6)';
+
+      await client.query({
+        text: query,
+        values: [channelId, moveChannelId, teamId, emojiText, limit, action,],
+      });
+    }
 
     RedisClient.DEL(`Tiddy_watcher:${channelId}-${teamId}-${emojiText}`);
   }


### PR DESCRIPTION
# Add Move Message Watcher

## What does this PR do

This PR adds the ability to add a move message watcher to the DB.

## Description of Task to be completed

- add move message watcher functionality
- modify watching_channel table
- add a new stored procedure

## How should this be manually tested

- Follow the instructions on the HOW_TO_CONTRIBUTE file
- Change all environment variables to your actual variables
- Build the production code using `npm run build`
- Setup ngrok and start the server.
- Add a new watcher with the move action.